### PR TITLE
Use service block instead of plist

### DIFF
--- a/opener.rb
+++ b/opener.rb
@@ -15,29 +15,12 @@ class Opener < Formula
     bin.install "opener"
   end
 
-  plist_options manual: "opener"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-      <dict>
-        <key>Label</key>
-        <string>#{plist_name}</string>
-        <key>RunAtLoad</key>
-        <true/>
-        <key>KeepAlive</key>
-        <true/>
-        <key>WorkingDirectory</key>
-        <string>#{HOMEBREW_PREFIX}</string>
-        <key>ProgramArguments</key>
-        <array>
-          <string>#{opt_bin}/opener</string>
-        </array>
-      </dict>
-      </plist>
-    EOS
+  service do
+    run opt_bin/"opener"
+    keep_alive true
+    working_dir HOMEBREW_PREFIX
+    log_path var/"log/opener.log"
+    error_log_path var/"log/opener.log"
   end
 end
 # vim: set fenc=utf-8 :


### PR DESCRIPTION
This PR uses `service` block instead of plist. With this change, `brew services` will be worked with Linuxbrew.